### PR TITLE
Python 3 support

### DIFF
--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -29,6 +29,7 @@ import random
 import traceback
 import networkx as nx
 from collections import namedtuple, defaultdict
+from six.moves import xrange
 
 DEBUG = False
 

--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -1975,7 +1975,7 @@ class controlFlowinator:
         print("[DEBUG] Writing DOT file...")
         od = "{}\\decompiled.dot".format(out_dir)
         with open(od, 'wb') as f:
-            f.write(dot)
+            f.write(bytes(bytearray(dot, "utf-8")))
 
         print("[DEBUG] Done.")
 

--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -941,9 +941,9 @@ def string_value(ins):
         raise TypeError
 
     str_ea = ins.obj_ea
-    str_type = GetStringType(str_ea) & 0xF
+    str_type = get_str_type(str_ea) & 0xF
 
-    return GetString(ea=str_ea, strtype=str_type)
+    return get_strlit_contents(str_ea, -1, str_type)
 
 
 def is_var(ins):
@@ -2152,7 +2152,7 @@ class callObj:
         """
 
         tif = tinfo_t()
-        get_tinfo2(self.call_ea, tif) or guess_tinfo2(self.call_ea, tif)
+        get_tinfo(tif, self.call_ea) or guess_tinfo(tif, self.call_ea)
         self.ret_type = tif.get_rettype()
 
     def __repr__(self):

--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -21,9 +21,9 @@ from idautils import *
 
 import ida_hexrays
 
-from compiler_consts import expr_condition
-from compiler_consts import expr_ctype  # To pretty print debug messages
-from compiler_consts import expr_final, expr_assignments, insn_conditions
+from FIDL.compiler_consts import expr_condition
+from FIDL.compiler_consts import expr_ctype  # To pretty print debug messages
+from FIDL.compiler_consts import expr_final, expr_assignments, insn_conditions
 
 import random
 import traceback

--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -46,6 +46,12 @@ def dprint(s=""):
     if DEBUG:
         print(s)
 
+# networkx expects nodes to be hashable. We monkey patch some of IDA's type to
+# implement the __hash__ method so they can be used as nodes.
+_hash_from_obj_id = lambda self: hash(self.obj_id)
+cexpr_t.__hash__ = _hash_from_obj_id
+cinsn_t.__hash__ = _hash_from_obj_id
+carg_t.__hash__ = _hash_from_obj_id
 
 def debug_get_break_statements(c):
     for n in c.g.nodes():

--- a/FIDL/docs/mock_hexrays.py
+++ b/FIDL/docs/mock_hexrays.py
@@ -30,7 +30,7 @@ def main():
             value = getattr(ih, name)
             f.write("m.{} = {}\n".format(name, value))
 
-    print "Done."
+    print("Done.")
 
 
 if __name__ == '__main__':

--- a/FIDL/examples/possible_malloc_issue.py
+++ b/FIDL/examples/possible_malloc_issue.py
@@ -91,8 +91,8 @@ def main():
         min_size=0,
         fast=False)
 
-    print "=" * 80
-    print results
+    print("=" * 80)
+    print(results)
 
 
 if __name__ == '__main__':

--- a/FIDL/tests/pytest_fidl.py
+++ b/FIDL/tests/pytest_fidl.py
@@ -19,12 +19,12 @@ def snow():
 
 
 def main():
-    print "-" * 60
-    print "Started tests at @ {}".format(snow())
+    print("-" * 60)
+    print("Started tests at @ {}".format(snow()))
 
     pytest.main(['--capture=sys', os.path.dirname(__file__)])
 
-    print "Finished tests at @ {}".format(snow())
+    print("Finished tests at @ {}".format(snow()))
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name='FIDL',
       license='MIT',
       install_requires=[
         'networkx',
+        'six',
       ],
       extras_require={
         'dev': [


### PR DESCRIPTION
Here is a patch to make FIDL work in IDA 7.4 and Python 3. Compatibility with Python 2 is unchanged.

Note that because of 9ae5697 I'm not sure if it will work with IDA 6 anymore. I'm not sure if this is something you want to support or not.

Note: Tests do not pass as-is. In fact, it didn't work for me with FIDL 1.0 under Python 2 either. I made a few changes that I'll share as a pull request later.