### PR TITLE
Use get_name_ea_simple to support IDA 7.4

### DIFF
--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -1306,7 +1306,7 @@ def display_all_calls_to(func_name):
     :type func_name: string
     """
 
-    f_ea = LocByName(func_name)
+    f_ea = get_name_ea_simple(func_name)
     if f_ea == BADADDR:
         print("Can not find {}".format(func_name))
         return None


### PR DESCRIPTION
This Pull Request is continuing the work of porting FIDL to IDA 7.4 API, fixing the LocByName usage.

fixes #4 