### PR TITLE
Populate ctree structure before accessing it.

### DIFF
--- a/FIDL/decompiler_utils.py
+++ b/FIDL/decompiler_utils.py
@@ -1039,6 +1039,7 @@ def my_decompile(ea=None):
                        ea=ea,
                        flags=ida_hexrays.DECOMP_NO_WAIT | ida_hexrays.DECOMP_NO_CACHE
                        )
+        cf.refresh_func_ctext()
     except ida_hexrays.DecompilationFailure as e:
         print("Failed to decompile @ {:X}".format(ea))
         cf = None


### PR DESCRIPTION
Fixes #12 by calling `refresh_func_ctext()` after `decompile()`.